### PR TITLE
add setImmediate to connected event

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -186,8 +186,9 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 				this.disconnect()
 				return
 			}
-
-			this.emit('connected')
+			setImmediate(() => {
+				this.emit('connected')
+			})
 		})
 
 		if (this._host) {


### PR DESCRIPTION
because `ipChange` is wrapped i `setImmediate` it can sometimes arrive after `connected` causing the `showStatusCard` loop to keep going
so we should maybe add `setImmediate` to  `connected` or remove it from  `ipChange`