### PR TITLE
wip: websocket connection

### DIFF
--- a/satellite/package.json
+++ b/satellite/package.json
@@ -31,6 +31,7 @@
         "@types/koa-static": "^4.0.4",
         "@types/node": "^20.17.1",
         "@types/semver": "^7.5.8",
+        "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "cross-env": "^7.0.3",
@@ -70,7 +71,8 @@
         "node-hid": "^3.1.2",
         "semver": "^7.6.3",
         "tslib": "^2.8.0",
-        "usb": "^2.14.0"
+        "usb": "^2.14.0",
+        "ws": "^8.18.0"
     },
     "lint-staged": {
         "*.{css,json,md,scss}": [

--- a/satellite/src/clientImplementations.ts
+++ b/satellite/src/clientImplementations.ts
@@ -1,0 +1,72 @@
+import { Socket } from 'net'
+import { WebSocket } from 'ws'
+
+export interface ICompanionSatelliteClientEvents {
+	error: [Error]
+	close: []
+	data: [Buffer]
+	connect: []
+}
+
+export interface ICompanionSatelliteClientOptions {
+	onError: (error: Error) => void
+	onClose: () => void
+	onData: (data: string) => void
+	onConnect: () => void
+}
+
+export interface ICompanionSatelliteClient {
+	write(data: string): void
+	end(): void
+	destroy(): void
+}
+
+export class CompanionSatelliteTcpClient implements ICompanionSatelliteClient {
+	#socket: Socket
+
+	constructor(options: ICompanionSatelliteClientOptions, host: string, port: number) {
+		this.#socket = new Socket()
+
+		this.#socket.on('error', (err) => options.onError(err))
+		this.#socket.on('close', () => options.onClose())
+		this.#socket.on('data', (data) => options.onData(data.toString()))
+		this.#socket.on('connect', () => options.onConnect())
+
+		this.#socket.connect(port, host)
+	}
+
+	write(data: string): void {
+		this.#socket.write(data)
+	}
+	end(): void {
+		this.#socket.end()
+	}
+	destroy(): void {
+		this.#socket.destroy()
+	}
+}
+
+export class CompanionSatelliteWsClient implements ICompanionSatelliteClient {
+	#socket: WebSocket
+
+	constructor(options: ICompanionSatelliteClientOptions, address: string) {
+		this.#socket = new WebSocket(address, {
+			timeout: 5000,
+		})
+
+		this.#socket.on('error', (err) => options.onError(err))
+		this.#socket.on('close', () => options.onClose())
+		this.#socket.on('message', (data) => options.onData(data.toString()))
+		this.#socket.on('open', () => options.onConnect())
+	}
+
+	write(data: string): void {
+		this.#socket.send(data)
+	}
+	end(): void {
+		this.#socket.terminate()
+	}
+	destroy(): void {
+		this.#socket.close()
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,6 +2001,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ws@npm:^8.5.12":
+  version: 8.5.12
+  resolution: "@types/ws@npm:8.5.12"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/3fd77c9e4e05c24ce42bfc7647f7506b08c40a40fe2aea236ef6d4e96fc7cb4006a81ed1b28ec9c457e177a74a72924f4768b7b4652680b42dfd52bc380e15f9
+  languageName: node
+  linkType: hard
+
 "@types/yauzl@npm:^2.9.1":
   version: 2.10.0
   resolution: "@types/yauzl@npm:2.10.0"
@@ -6776,6 +6785,7 @@ __metadata:
     "@types/koa-static": "npm:^4.0.4"
     "@types/node": "npm:^20.17.1"
     "@types/semver": "npm:^7.5.8"
+    "@types/ws": "npm:^8.5.12"
     "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
     "@typescript-eslint/parser": "npm:^7.18.0"
     "@xencelabs-quick-keys/node": "npm:^1.0.0"
@@ -6805,6 +6815,7 @@ __metadata:
     tslib: "npm:^2.8.0"
     tsx: "npm:^4.19.1"
     usb: "npm:^2.14.0"
+    ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft
 
@@ -7786,6 +7797,21 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
POC to utilise https://github.com/bitfocus/companion/commit/bea03af8a0df9330b04ca1feddc9d931c27ae077
https://github.com/bitfocus/companion/issues/3101

This is intended to be an alternate connection method. By using websocket, it is easier to add on external authentication to the connection, using any reverse proxy (eg nginx/traefik)

TODO:

- [ ] Add new config fields to define connection mode, and wsAddress
- [ ] When setting host/port/wsAddress over the rest api, should it auto-switch to be using that protocol?
- [ ] UI to configure this
- [ ] Support for setting authorization header?