### PR TITLE
Small UI fix to strip https:// http:// and trailing / + whitespaces

### DIFF
--- a/webui/src/app/ConnectionConfig.tsx
+++ b/webui/src/app/ConnectionConfig.tsx
@@ -104,7 +104,6 @@ function ConnectionConfigContent({ config }: { config: ApiConfigData }): JSX.Ele
 												let value = e.target.value
 												value = value.trim()
 												value = value.replace(/^https?:\/\//, '')
-												value = value.replace(/\/$/, '')
 												value = value.replace(/\/+$/, '')
 												field.handleChange(value)
 											}}

--- a/webui/src/app/ConnectionConfig.tsx
+++ b/webui/src/app/ConnectionConfig.tsx
@@ -100,7 +100,14 @@ function ConnectionConfigContent({ config }: { config: ApiConfigData }): JSX.Ele
 											placeholder="Companion address (eg 127.0.0.1 or companion.local)"
 											value={field.state.value}
 											onBlur={field.handleBlur}
-											onChange={(e) => field.handleChange(e.target.value)}
+											onChange={(e) => {
+												let value = e.target.value
+												value = value.replace(/^https?:\/\//, '')
+												value = value.replace(/\/$/, '')
+												value = value.trim()
+												value = value.replace(/\/+$/, '')
+												field.handleChange(value)
+											}}
 										/>
 									</FormRow>
 								)}

--- a/webui/src/app/ConnectionConfig.tsx
+++ b/webui/src/app/ConnectionConfig.tsx
@@ -102,9 +102,9 @@ function ConnectionConfigContent({ config }: { config: ApiConfigData }): JSX.Ele
 											onBlur={field.handleBlur}
 											onChange={(e) => {
 												let value = e.target.value
+												value = value.trim()
 												value = value.replace(/^https?:\/\//, '')
 												value = value.replace(/\/$/, '')
-												value = value.trim()
 												value = value.replace(/\/+$/, '')
 												field.handleChange(value)
 											}}


### PR DESCRIPTION
This PR adds the removal of : 
- https://
- http://
- whitespaces
- trailing / 
The goal here is to remove a common error I see where Users copy the companion URL from their browser in here and forget to remove https:// and the trailing slash 

I tested that it works correctly with these : 
- http://localhost/ -> localhost
- http://127.0.0.1/ -> 127.0.0.1
- http://10.10.20.212/ -> 10.10.20.212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host field in connection settings now normalizes input: trims surrounding whitespace, removes leading "http://" or "https://", and strips trailing slashes (including repeated slashes) before saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->