### PR TITLE
feat: surface gauge support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,6 +104,7 @@ export default [
 			'**/node_modules/*',
 			'**/electron-output/*',
 			'webui/vite.config.ts',
+			'**/vitest.config.ts',
 			'pi-image/**/*',
 			'.cache/**/*',
 		],

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
     "zx": "^8.8.5"
   },
   "resolutions": {
-    "node-gyp": "^12.3.0"
+    "node-gyp": "^12.3.0",
+    "@companion-surface/base": "1.4.0-nightly-main-20260714-131236-17ba70a",
+    "@companion-surface/host": "1.3.3-nightly-main-20260713-213540-a42afb9"
   },
   "engines": {
     "node": "^24.13"

--- a/package.json
+++ b/package.json
@@ -72,9 +72,7 @@
     "zx": "^8.8.5"
   },
   "resolutions": {
-    "node-gyp": "^12.3.0",
-    "@companion-surface/base": "1.4.0-nightly-main-20260714-131236-17ba70a",
-    "@companion-surface/host": "1.3.3-nightly-main-20260713-213540-a42afb9"
+    "node-gyp": "^12.3.0"
   },
   "engines": {
     "node": "^24.13"

--- a/satellite/package.json
+++ b/satellite/package.json
@@ -31,7 +31,7 @@
 		"node": "^24.13"
 	},
 	"dependencies": {
-		"@companion-surface/host": "^1.3.3",
+		"@companion-surface/host": "^1.4.0",
 		"@julusian/bonjour-service": "^1.4.4",
 		"@julusian/image-rs": "^2.1.1",
 		"@julusian/segfault-raub": "^2.3.3",

--- a/satellite/src/__tests__/translateSchema.test.ts
+++ b/satellite/src/__tests__/translateSchema.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import type { SurfaceSchemaLayoutDefinition } from '@companion-surface/host'
+import { stripUnsupportedManifestFeatures, translateModuleToSatelliteSurfaceLayout } from '../translateSchema.js'
+import type { SatelliteSurfaceLayout } from '../generated/SurfaceManifestSchema.js'
+
+describe('translateModuleToSatelliteSurfaceLayout', () => {
+	it('passes leds config through unchanged', () => {
+		const moduleLayout: SurfaceSchemaLayoutDefinition = {
+			stylePresets: {
+				default: { leds: { segments: 24, mode: 'full-ring' } },
+			},
+			controls: {
+				'0/0': { row: 0, column: 0 },
+			},
+		}
+
+		const result = translateModuleToSatelliteSurfaceLayout(moduleLayout)
+
+		expect(result.stylePresets.default.leds).toEqual({ segments: 24, mode: 'full-ring' })
+	})
+
+	it('leaves leds undefined when the preset does not declare it', () => {
+		const moduleLayout: SurfaceSchemaLayoutDefinition = {
+			stylePresets: {
+				default: { bitmap: { w: 72, h: 72 }, colors: 'hex' },
+			},
+			controls: {
+				'0/0': { row: 0, column: 0 },
+			},
+		}
+
+		const result = translateModuleToSatelliteSurfaceLayout(moduleLayout)
+
+		expect(result.stylePresets.default.leds).toBeUndefined()
+	})
+})
+
+describe('stripUnsupportedManifestFeatures', () => {
+	const makeManifest = (): SatelliteSurfaceLayout => ({
+		stylePresets: {
+			default: { bitmap: { w: 72, h: 72 }, colors: 'hex', text: true },
+			ring: { leds: { segments: 24, mode: 'full-ring' }, colors: 'rgb' },
+		},
+		controls: {
+			'0/0': { row: 0, column: 0 },
+			'0/1': { row: 0, column: 1, stylePreset: 'ring' },
+		},
+	})
+
+	it('removes leds from every style preset when the host does not support it', () => {
+		const manifest = makeManifest()
+
+		const result = stripUnsupportedManifestFeatures(manifest, { supportsLeds: false })
+
+		expect(result.stylePresets.ring.leds).toBeUndefined()
+		expect(result.stylePresets.default.leds).toBeUndefined()
+		// No `leds` key anywhere in the serialized manifest that Companion would reject
+		expect(JSON.stringify(result)).not.toContain('leds')
+
+		// Other properties and controls are untouched
+		expect(result.stylePresets.default).toMatchObject({ bitmap: { w: 72, h: 72 }, colors: 'hex', text: true })
+		expect(result.stylePresets.ring.colors).toBe('rgb')
+		expect(result.controls).toEqual(manifest.controls)
+	})
+
+	it('preserves leds when the host supports it', () => {
+		const manifest = makeManifest()
+
+		const result = stripUnsupportedManifestFeatures(manifest, { supportsLeds: true })
+
+		expect(result.stylePresets.ring.leds).toEqual({ segments: 24, mode: 'full-ring' })
+	})
+
+	it('does not mutate the input manifest', () => {
+		const manifest = makeManifest()
+
+		stripUnsupportedManifestFeatures(manifest, { supportsLeds: false })
+
+		expect(manifest.stylePresets.ring.leds).toEqual({ segments: 24, mode: 'full-ring' })
+	})
+})

--- a/satellite/src/client/client.ts
+++ b/satellite/src/client/client.ts
@@ -12,6 +12,7 @@ import {
 import { SatelliteControlDefinition, SatelliteSurfaceLayout } from '../generated/SurfaceManifestSchema.js'
 import { SatelliteConfigFields } from '../generated/SatelliteConfigFieldsSchema.js'
 import { parseLineParameters } from './parser.js'
+import { stripUnsupportedManifestFeatures } from '../translateSchema.js'
 import type { GridSize } from '@companion-surface/host'
 
 const PING_UNACKED_LIMIT = 15 // Arbitrary number
@@ -43,6 +44,7 @@ export interface CompanionSatelliteClientDrawProps {
 	type?: string
 	pressed?: boolean
 	location?: string
+	leds?: string // base64 packed raw rgb, 3 bytes per LED segment
 }
 
 export interface DeviceRegisterProps {
@@ -119,6 +121,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 	private _supportsDeviceSerial = false
 	private _supportsSubscriptions = false
 	private _supportsNonSquareBitmaps = false
+	private _supportsLedsCapability = false
 	private _companionBitmapFormats: string[] = []
 	private _pendingConnected = false
 
@@ -152,6 +155,10 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 	}
 	public get supportsNonSquareBitmaps(): boolean {
 		return this._supportsNonSquareBitmaps
+	}
+	/** Whether Companion supports addressable-LED controls (`leds` capability, API v1.13.0+) */
+	public get supportsLeds(): boolean {
+		return this._supportsLedsCapability
 	}
 
 	/**
@@ -455,6 +462,10 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 		if (this._supportsDeviceSerial) {
 			this.emit('log', 'Companion supports separate serial value')
 		}
+		this._supportsLedsCapability = !!this._companionApiVersion && semver.lte('1.13.0', this._companionApiVersion)
+		if (this._supportsLedsCapability) {
+			this.emit('log', 'Companion supports addressable LEDs')
+		}
 		this._supportsNonSquareBitmaps = false
 		this._supportsSubscriptions = false
 		this._companionBitmapFormats = []
@@ -501,6 +512,8 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 		const type = typeof params.TYPE === 'string' ? params.TYPE : undefined
 		const pressed = typeof params.PRESSED === 'string' ? params.PRESSED === '1' : undefined
 		const location = typeof params.LOCATION === 'string' ? params.LOCATION : undefined
+		// LEDS is always base64 of a packed raw-rgb buffer (3 bytes per segment), never a data url.
+		const leds = typeof params.LEDS === 'string' ? params.LEDS : undefined
 
 		this.emit('draw', {
 			deviceId: params.DEVICEID,
@@ -514,6 +527,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 			type,
 			pressed,
 			location,
+			leds,
 		} satisfies Complete<CompanionSatelliteClientDrawProps>)
 	}
 	private handleClear(params: Record<string, string | boolean>): void {
@@ -790,8 +804,14 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 				const bitmapFormatArgs: SatelliteMessageArgs =
 					bitmapFormat !== 'rgb' ? { BITMAP_FORMAT: bitmapFormat } : {}
 
+				// Strip manifest features the connected Companion is too old to understand, so it
+				// doesn't reject the whole manifest (it validates with `additionalProperties: false`).
+				const manifest = stripUnsupportedManifestFeatures(props.surfaceManifest, {
+					supportsLeds: this._supportsLedsCapability,
+				})
+
 				this.sendMessage('ADD-DEVICE', null, deviceId, {
-					LAYOUT_MANIFEST: Buffer.from(JSON.stringify(props.surfaceManifest)).toString('base64'),
+					LAYOUT_MANIFEST: Buffer.from(JSON.stringify(manifest)).toString('base64'),
 					...commonProps,
 					...serialArgs,
 					...configFieldsArgs,

--- a/satellite/src/generated/SurfaceManifestSchema.ts
+++ b/satellite/src/generated/SurfaceManifestSchema.ts
@@ -40,6 +40,7 @@ export interface SatelliteControlStylePreset {
 	 * If set, the control requests colours to be reported.
 	 */
 	colors?: 'hex' | 'rgb'
+	leds?: SatelliteLedsConfig
 }
 /**
  * If set, bitmaps of the specified size will be reported.
@@ -53,6 +54,19 @@ export interface SatelliteConfigSize {
 	 * Height in pixels (non-negative).
 	 */
 	h: number
+}
+/**
+ * If set, the control has an addressable strip/ring of LEDs and requests LED colours to be reported.
+ */
+export interface SatelliteLedsConfig {
+	/**
+	 * The number of individually addressable LED segments.
+	 */
+	segments: number
+	/**
+	 * How Companion maps a gauge onto these LEDs. `full-ring`: the LEDs form a complete circle and the gauge is rendered faithfully (angles, deadzone and colours respected 1:1); segment 0 is at 6 o'clock and indices increase clockwise. `simple`: any other shape where the value is swept across all segments, with segment 0 as the 0% end. In both cases the surface re-maps to its physical wiring locally if it differs from these conventions.
+	 */
+	mode: 'full-ring' | 'simple'
 }
 /**
  * Single control definition. The id must be unique and may be user facing in logs. Typically the id would be in the form of 1/0, matching the row/column of the control.

--- a/satellite/src/surface-manager.ts
+++ b/satellite/src/surface-manager.ts
@@ -66,6 +66,7 @@ export class SurfaceManager {
 	#enabledPluginsConfig: ApiSurfacePluginsEnabled = {}
 
 	#supportsNonSquareButtons: boolean = false
+	#supportsLeds: boolean = false
 
 	#statusString: string
 	#scanIsRunning = false
@@ -203,7 +204,7 @@ export class SurfaceManager {
 						// register response, which would cause the child to call process.exit(11).
 						if (manager.isPluginEnabled(pluginId)) {
 							handler
-								.init(manager.#supportsNonSquareButtons)
+								.init(manager.#supportsNonSquareButtons, manager.#supportsLeds)
 								.then(() => {
 									const entry = manager.#plugins.get(pluginId)
 									if (entry) entry.initialized = true
@@ -277,12 +278,19 @@ export class SurfaceManager {
 
 			this.#showStatusCard('Connected', false)
 
-			const newSupportsNonSquareButtons: boolean | undefined = client.supportsNonSquareBitmaps
-			if (newSupportsNonSquareButtons !== this.#supportsNonSquareButtons) {
+			// A module reads host capabilities once at init() time, so any change requires restarting
+			// all modules so they re-init (and re-evaluate whether to declare e.g. `leds`).
+			const newSupportsNonSquareButtons: boolean = client.supportsNonSquareBitmaps
+			const newSupportsLeds: boolean = client.supportsLeds
+			if (
+				newSupportsNonSquareButtons !== this.#supportsNonSquareButtons ||
+				newSupportsLeds !== this.#supportsLeds
+			) {
 				this.#logger.info(
-					`supportsNonSquareButtons changed from ${this.#supportsNonSquareButtons} to ${newSupportsNonSquareButtons}, restarting all modules`,
+					`Host capabilities changed (supportsNonSquareButtons: ${this.#supportsNonSquareButtons}->${newSupportsNonSquareButtons}, supportsLeds: ${this.#supportsLeds}->${newSupportsLeds}), restarting all modules`,
 				)
 				this.#supportsNonSquareButtons = newSupportsNonSquareButtons
+				this.#supportsLeds = newSupportsLeds
 				for (const [, entry] of this.#plugins.entries()) {
 					if (entry.initialized) {
 						entry.initialized = false
@@ -402,6 +410,7 @@ export class SurfaceManager {
 							image: image,
 							color: msg.color,
 							text: msg.text,
+							leds: preset?.leds ? msg.leds : undefined,
 						} satisfies Complete<IpcDrawProps>,
 					])
 				},

--- a/satellite/src/surface-thread/child-handler.ts
+++ b/satellite/src/surface-thread/child-handler.ts
@@ -204,8 +204,8 @@ export class ChildHandler {
 		}
 	}
 
-	async init(supportsNonSquareButtons: boolean | undefined): Promise<void> {
-		await this.#ipcWrapper.sendWithCb('init', { supportsNonSquareButtons })
+	async init(supportsNonSquareButtons: boolean | undefined, supportsLeds: boolean | undefined): Promise<void> {
+		await this.#ipcWrapper.sendWithCb('init', { supportsNonSquareButtons, supportsLeds })
 	}
 
 	/**

--- a/satellite/src/surface-thread/entrypoint.ts
+++ b/satellite/src/surface-thread/entrypoint.ts
@@ -46,6 +46,7 @@ async function main() {
 
 				// This is safe, as the plugin doesn't have access to the capabilities until we call init
 				hostContext.capabilities.supportsNonSquareButtons = msg.supportsNonSquareButtons
+				hostContext.capabilities.supportsLeds = msg.supportsLeds
 
 				await plugin.init()
 
@@ -157,6 +158,7 @@ async function main() {
 					msg.drawProps.map((d) => ({
 						...d,
 						image: d.image ? Buffer.from(d.image, 'base64') : undefined,
+						leds: d.leds ? Buffer.from(d.leds, 'base64') : undefined,
 					})),
 				)
 			},

--- a/satellite/src/surface-thread/host-context.ts
+++ b/satellite/src/surface-thread/host-context.ts
@@ -18,7 +18,7 @@ export class HostContext implements SurfaceHostContext {
 	readonly lockingGraphics = new LockingGraphicsGeneratorImpl()
 	readonly cardsGenerator = new CardGenerator()
 
-	readonly capabilities: HostCapabilities = { supportsNonSquareButtons: undefined }
+	readonly capabilities: HostCapabilities = { supportsNonSquareButtons: undefined, supportsLeds: undefined }
 
 	readonly surfaceEvents: HostSurfaceEvents
 

--- a/satellite/src/surface-thread/ipc-types.ts
+++ b/satellite/src/surface-thread/ipc-types.ts
@@ -36,6 +36,7 @@ export interface SurfaceModuleToHostEvents {
 
 export interface InitMessage {
 	supportsNonSquareButtons: boolean | undefined
+	supportsLeds: boolean | undefined
 }
 
 export interface HostToSurfaceModuleEvents {
@@ -188,8 +189,9 @@ export interface DrawControlMessage {
 	drawProps: IpcDrawProps[]
 }
 
-export interface IpcDrawProps extends Omit<SurfaceDrawProps, 'image'> {
+export interface IpcDrawProps extends Omit<SurfaceDrawProps, 'image' | 'leds'> {
 	image?: string // base64-encoded
+	leds?: string // base64-encoded (packed raw rgb, 3 bytes per segment)
 }
 
 export interface BlankSurfaceMessage {

--- a/satellite/src/translateSchema.ts
+++ b/satellite/src/translateSchema.ts
@@ -49,6 +49,7 @@ export function translateModuleToSatelliteSurfaceLayout(
 			text: preset.text,
 			textStyle: preset.textStyle,
 			colors: preset.colors,
+			leds: preset.leds ? { segments: preset.leds.segments, mode: preset.leds.mode } : undefined,
 		} satisfies Complete<SatelliteControlStylePreset>
 	}
 
@@ -61,6 +62,32 @@ export function translateModuleToSatelliteSurfaceLayout(
 	}
 
 	return translatedLayout
+}
+
+/**
+ * Remove manifest features that the connected Companion is too old to understand, before the manifest
+ * is sent as `LAYOUT_MANIFEST`. Companion validates the manifest strictly (`additionalProperties: false`),
+ * so an unknown property would cause it to reject the whole manifest and fail to register the surface.
+ *
+ * Returns a copy; the input is not mutated.
+ */
+export function stripUnsupportedManifestFeatures(
+	manifest: SatelliteSurfaceLayout,
+	support: { supportsLeds: boolean },
+): SatelliteSurfaceLayout {
+	// `leds` was added in API v1.13.0
+	if (support.supportsLeds) return manifest
+
+	const stylePresets: SatelliteSurfaceLayout['stylePresets'] = { default: {} }
+	for (const [presetId, preset] of Object.entries(manifest.stylePresets)) {
+		const { leds: _leds, ...rest } = preset
+		stylePresets[presetId] = rest
+	}
+
+	return {
+		...manifest,
+		stylePresets,
+	}
 }
 
 export function translateModuleToSatelliteTransferVariables(

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,23 +396,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@companion-surface/base@npm:~1.3.0":
-  version: 1.3.0
-  resolution: "@companion-surface/base@npm:1.3.0"
-  dependencies:
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/86b7a7955dfc6e9dd2bd269cee81b94a0b1acda107922262d76f4f198983548841b074c6a0698732e584b77ee2f2e80aa211482bb7b3e3b37623dc5c0bc2f0db
+"@companion-surface/base@npm:1.4.0-nightly-main-20260714-131236-17ba70a":
+  version: 1.4.0-nightly-main-20260714-131236-17ba70a
+  resolution: "@companion-surface/base@npm:1.4.0-nightly-main-20260714-131236-17ba70a"
+  checksum: 10c0/6cda7bb1aa57cd619e7b18cf60221d8e8c58d40ca8dc00020bfd08d1c6e83e70b6fb61c3ef7f6c200788c0020d3079cd36cd9ebb2410845f16cd374476a0c6e9
   languageName: node
   linkType: hard
 
-"@companion-surface/host@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "@companion-surface/host@npm:1.3.3"
+"@companion-surface/host@npm:1.3.3-nightly-main-20260713-213540-a42afb9":
+  version: 1.3.3-nightly-main-20260713-213540-a42afb9
+  resolution: "@companion-surface/host@npm:1.3.3-nightly-main-20260713-213540-a42afb9"
   dependencies:
     "@companion-surface/base": "npm:~1.3.0"
     fast-deep-equal: "npm:^3.1.3"
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/35cf849d69509db7465f4d3b1d330800243737fda89fe0b8be3b549d8b609d8e11fc90ecbca5b66895a36eefb840ea493427a98190f58a63c357f66364dbff25
+  checksum: 10c0/a1f99af3bc8c52b2777a187b2e01b4e30ceaeccbcddf8a0198295cf8d2bb1948477235bd64a22c93757c7fd0da5dfc09a93a3e16c89998ad5a731996d13b5581
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,20 +396,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@companion-surface/base@npm:1.4.0-nightly-main-20260714-131236-17ba70a":
-  version: 1.4.0-nightly-main-20260714-131236-17ba70a
-  resolution: "@companion-surface/base@npm:1.4.0-nightly-main-20260714-131236-17ba70a"
-  checksum: 10c0/6cda7bb1aa57cd619e7b18cf60221d8e8c58d40ca8dc00020bfd08d1c6e83e70b6fb61c3ef7f6c200788c0020d3079cd36cd9ebb2410845f16cd374476a0c6e9
+"@companion-surface/base@npm:~1.4.0":
+  version: 1.4.0
+  resolution: "@companion-surface/base@npm:1.4.0"
+  dependencies:
+    zod: "npm:^4.4.3"
+  checksum: 10c0/8b50af17ee832a8f5e13cfde5958e846be36fd5a3709174faec80e01aab27c84e2302160ce94ac727a6dd23e0dda8249604858e066a06f7ceb10ced8272614d0
   languageName: node
   linkType: hard
 
-"@companion-surface/host@npm:1.3.3-nightly-main-20260713-213540-a42afb9":
-  version: 1.3.3-nightly-main-20260713-213540-a42afb9
-  resolution: "@companion-surface/host@npm:1.3.3-nightly-main-20260713-213540-a42afb9"
+"@companion-surface/host@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@companion-surface/host@npm:1.4.0"
   dependencies:
-    "@companion-surface/base": "npm:~1.3.0"
+    "@companion-surface/base": "npm:~1.4.0"
     fast-deep-equal: "npm:^3.1.3"
-  checksum: 10c0/a1f99af3bc8c52b2777a187b2e01b4e30ceaeccbcddf8a0198295cf8d2bb1948477235bd64a22c93757c7fd0da5dfc09a93a3e16c89998ad5a731996d13b5581
+  checksum: 10c0/ea01491a94b6eaaf8a752082bba48d06b7253fd55b1f1c27b9f96ed7dded7f791f4aabf1b36e51f961e25241841dea7f97400c4c0fa0d3e7d1e9a7a73e63efb7
   languageName: node
   linkType: hard
 
@@ -8379,7 +8381,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "satellite@workspace:satellite"
   dependencies:
-    "@companion-surface/host": "npm:^1.3.3"
+    "@companion-surface/host": "npm:^1.4.0"
     "@julusian/bonjour-service": "npm:^1.4.4"
     "@julusian/image-rs": "npm:^2.1.1"
     "@julusian/segfault-raub": "npm:^2.3.3"


### PR DESCRIPTION
partner to https://github.com/bitfocus/companion/pull/4314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for addressable LED effects in surface layouts and control drawing.
  * LED capabilities are detected automatically, enabling compatible Companion connections to display LED data.
  * Added compatibility handling so LED settings are omitted when unsupported.
  * Surface modules now recognize host LED capabilities and refresh when capabilities change.

* **Tests**
  * Added coverage for LED configuration translation, capability handling, unsupported-feature removal, and input immutability.

* **Chores**
  * Updated linting exclusions for Vitest configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->