### PR TITLE
fix: harden reconnect and device registration recovery

### DIFF
--- a/satellite/src/client/__tests__/client-recovery.test.ts
+++ b/satellite/src/client/__tests__/client-recovery.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CompanionSatelliteClient, type CompanionSatelliteSocketFactory, type DeviceRegisterProps } from '../client.js'
+import type { ICompanionSatelliteClient, ICompanionSatelliteClientOptions } from '../socketImplementations.js'
+
+class FakeSocket implements ICompanionSatelliteClient {
+	readonly writes: string[] = []
+	destroyed = false
+	autoPong = false
+
+	constructor(private readonly options: ICompanionSatelliteClientOptions) {}
+
+	connect(): void {
+		this.options.onConnect()
+	}
+
+	receive(data: string): void {
+		this.options.onData(data)
+	}
+
+	close(): void {
+		this.options.onClose()
+	}
+
+	write(data: string): void {
+		this.writes.push(data)
+		if (this.autoPong && data === 'PING\n') this.receive('PONG\n')
+	}
+
+	end(): void {}
+
+	destroy(): void {
+		this.destroyed = true
+	}
+}
+
+function createClient(): { client: CompanionSatelliteClient; sockets: FakeSocket[] } {
+	const sockets: FakeSocket[] = []
+	const socketFactory: CompanionSatelliteSocketFactory = (options) => {
+		const socket = new FakeSocket(options)
+		sockets.push(socket)
+		return socket
+	}
+
+	return {
+		client: new CompanionSatelliteClient({ socketFactory }),
+		sockets,
+	}
+}
+
+const registerProps: DeviceRegisterProps = {
+	serialNumber: 'test-serial',
+	serialIsUnique: true,
+	brightness: true,
+	surfaceManifest: { stylePresets: {} } as DeviceRegisterProps['surfaceManifest'],
+	transferVariables: undefined,
+	configFields: undefined,
+	canChangePage: undefined,
+	gridSize: { columns: 8, rows: 4 },
+	fallbackBitmapSize: 72,
+}
+
+describe('CompanionSatelliteClient recovery', () => {
+	beforeEach(() => vi.useFakeTimers())
+	afterEach(() => vi.useRealTimers())
+
+	it('reconnects when the Satellite handshake never completes, even while pongs arrive', async () => {
+		const { client, sockets } = createClient()
+		const logs: string[] = []
+		client.on('log', (message) => logs.push(message))
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
+		const socket = sockets[0]
+		socket.autoPong = true
+		socket.connect()
+
+		await vi.advanceTimersByTimeAsync(10000)
+
+		expect(socket.destroyed).toBe(true)
+		expect(logs).toContain('Satellite handshake timeout')
+	})
+
+	it('ignores a delayed close callback from a superseded socket', async () => {
+		const { client, sockets } = createClient()
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
+		sockets[0].connect()
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.2', port: 16622 })
+		sockets[1].connect()
+		sockets[0].close()
+
+		expect(client.connected).toBe(true)
+	})
+
+	it('releases a device for an isolated retry when registration is not acknowledged', async () => {
+		const { client, sockets } = createClient()
+		const deviceErrors: string[] = []
+		client.on('deviceErrored', ({ deviceId }) => deviceErrors.push(deviceId))
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
+		sockets[0].autoPong = true
+		sockets[0].connect()
+		client.addDevice('deck-1', 'Test Deck', registerProps)
+
+		expect(client.hasDevice('deck-1')).toBe(true)
+		await vi.advanceTimersByTimeAsync(10000)
+
+		expect(client.hasDevice('deck-1')).toBe(false)
+		expect(deviceErrors).toEqual(['deck-1'])
+	})
+
+	it('cancels the registration watchdog after Companion acknowledges the device', async () => {
+		const { client, sockets } = createClient()
+		const deviceErrors: string[] = []
+		client.on('deviceErrored', ({ deviceId }) => deviceErrors.push(deviceId))
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
+		sockets[0].autoPong = true
+		sockets[0].connect()
+		client.addDevice('deck-1', 'Test Deck', registerProps)
+		sockets[0].receive('ADD-DEVICE OK DEVICEID="deck-1"\n')
+
+		await vi.advanceTimersByTimeAsync(10000)
+
+		expect(client.hasDevice('deck-1')).toBe(true)
+		expect(deviceErrors).toEqual([])
+	})
+
+	it('releases a rejected device so the existing retry path can re-add it', async () => {
+		const { client, sockets } = createClient()
+		const deviceErrors: string[] = []
+		client.on('deviceErrored', ({ deviceId }) => deviceErrors.push(deviceId))
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
+		sockets[0].connect()
+		client.addDevice('deck-1', 'Test Deck', registerProps)
+		sockets[0].receive('ADD-DEVICE ERROR DEVICEID="deck-1" MESSAGE="Rejected"\n')
+
+		expect(client.hasDevice('deck-1')).toBe(false)
+		expect(deviceErrors).toEqual(['deck-1'])
+	})
+})

--- a/satellite/src/client/__tests__/client-recovery.test.ts
+++ b/satellite/src/client/__tests__/client-recovery.test.ts
@@ -6,6 +6,7 @@ class FakeSocket implements ICompanionSatelliteClient {
 	readonly writes: string[] = []
 	destroyed = false
 	autoPong = false
+	ackDeviceSynchronously = false
 
 	constructor(private readonly options: ICompanionSatelliteClientOptions) {}
 
@@ -24,6 +25,9 @@ class FakeSocket implements ICompanionSatelliteClient {
 	write(data: string): void {
 		this.writes.push(data)
 		if (this.autoPong && data === 'PING\n') this.receive('PONG\n')
+		if (this.ackDeviceSynchronously && data.startsWith('ADD-DEVICE ')) {
+			this.receive('ADD-DEVICE OK DEVICEID="deck-1"\n')
+		}
 	}
 
 	end(): void {}
@@ -77,6 +81,10 @@ describe('CompanionSatelliteClient recovery', () => {
 
 		expect(socket.destroyed).toBe(true)
 		expect(logs).toContain('Satellite handshake timeout')
+
+		socket.close()
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(sockets).toHaveLength(2)
 	})
 
 	it('ignores a delayed close callback from a superseded socket', async () => {
@@ -90,6 +98,22 @@ describe('CompanionSatelliteClient recovery', () => {
 		sockets[0].close()
 
 		expect(client.connected).toBe(true)
+	})
+
+	it('lets the active close callback finish an explicit disconnect', async () => {
+		const { client, sockets } = createClient()
+		const disconnected = vi.fn()
+		client.on('disconnected', disconnected)
+
+		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
+		sockets[0].connect()
+		client.disconnect()
+		sockets[0].close()
+
+		expect(client.connected).toBe(false)
+		expect(disconnected).toHaveBeenCalledOnce()
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(sockets).toHaveLength(1)
 	})
 
 	it('releases a device for an isolated retry when registration is not acknowledged', async () => {
@@ -109,16 +133,16 @@ describe('CompanionSatelliteClient recovery', () => {
 		expect(deviceErrors).toEqual(['deck-1'])
 	})
 
-	it('cancels the registration watchdog after Companion acknowledges the device', async () => {
+	it('cancels the registration watchdog after a synchronous acknowledgement', async () => {
 		const { client, sockets } = createClient()
 		const deviceErrors: string[] = []
 		client.on('deviceErrored', ({ deviceId }) => deviceErrors.push(deviceId))
 
 		await client.connect({ mode: 'tcp', host: '127.0.0.1', port: 16622 })
 		sockets[0].autoPong = true
+		sockets[0].ackDeviceSynchronously = true
 		sockets[0].connect()
 		client.addDevice('deck-1', 'Test Deck', registerProps)
-		sockets[0].receive('ADD-DEVICE OK DEVICEID="deck-1"\n')
 
 		await vi.advanceTimersByTimeAsync(10000)
 

--- a/satellite/src/client/client.ts
+++ b/satellite/src/client/client.ts
@@ -19,6 +19,8 @@ const PING_IDLE_TIMEOUT = 1000 // Pings are allowed to be late if another packet
 const PING_INTERVAL = 100
 const RECONNECT_DELAY = 1000
 const RECONNECT_DELAY_UNSUPPORTED = 30000
+const HANDSHAKE_TIMEOUT = 10000
+const DEVICE_REGISTRATION_TIMEOUT = 10000
 
 const MINIMUM_PROTOCOL_VERSION = '1.7.0' // Companion 3.4
 
@@ -29,6 +31,28 @@ const PREFERRED_BITMAP_FORMATS = ['webp', 'png'] as const
 
 export interface CompanionSatelliteClientOptions {
 	debug?: boolean
+	/** @internal Allows the transport to be replaced in focused client tests. */
+	socketFactory?: CompanionSatelliteSocketFactory
+}
+
+export type CompanionSatelliteSocketFactory = (
+	options: ICompanionSatelliteClientOptions,
+	details: SomeConnectionDetails,
+) => ICompanionSatelliteClient
+
+function createCompanionSatelliteSocket(
+	options: ICompanionSatelliteClientOptions,
+	details: SomeConnectionDetails,
+): ICompanionSatelliteClient {
+	switch (details.mode) {
+		case 'tcp':
+			return new CompanionSatelliteTcpClient(options, details)
+		case 'ws':
+			return new CompanionSatelliteWsClient(options, details)
+		default:
+			assertNever(details)
+			throw new Error('Invalid connection mode')
+	}
 }
 
 export interface CompanionSatelliteClientDrawProps {
@@ -95,11 +119,13 @@ export type CompanionSatelliteClientEvents = {
 
 export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteClientEvents> {
 	private readonly debug: boolean
+	private readonly socketFactory: CompanionSatelliteSocketFactory
 	private socket: ICompanionSatelliteClient | undefined
 
 	private receiveBuffer = ''
 
 	private _pingInterval: NodeJS.Timeout | undefined
+	private _handshakeTimeout: NodeJS.Timeout | undefined
 	private _pingUnackedCount = 0
 	private _lastReceivedAt = 0
 	private _connected = false
@@ -109,6 +135,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 
 	private _registeredDevices = new Set<string>()
 	private _pendingDevices = new Map<string, number>() // Time submitted
+	private _pendingDeviceTimeouts = new Map<string, NodeJS.Timeout>()
 
 	private _companionVersion: string | null = null
 	private _companionApiVersion: string | null = null
@@ -192,6 +219,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 		super()
 
 		this.debug = !!options.debug
+		this.socketFactory = options.socketFactory ?? createCompanionSatelliteSocket
 
 		// Don't auto initSocket, as that can trigger an uncaught error
 	}
@@ -209,15 +237,22 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 
 		const socketOptions: ICompanionSatelliteClientOptions = {
 			onError: (e) => {
+				if (this.socket !== socket) return
 				this.emit('error', e)
 			},
 			onClose: () => {
+				// A superseded socket can report close after its replacement is already
+				// active. It must not reset the replacement's connection state.
+				if (this.socket !== socket) return
+				this.socket = undefined
+
 				if (this.debug) {
 					this.emit('log', 'Connection closed')
 				}
 
 				this._registeredDevices.clear()
-				this._pendingDevices.clear()
+				this.clearPendingDevices()
+				this.clearHandshakeTimeout()
 
 				this._supportsSubscriptions = false
 				this._companionBitmapFormats = []
@@ -235,7 +270,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 					this._pingInterval = undefined
 				}
 
-				if (!this._retryConnectTimeout && this.socket === socket) {
+				if (!this._retryConnectTimeout && this._connectionActive) {
 					this._retryConnectTimeout = setTimeout(
 						() => {
 							this._retryConnectTimeout = undefined
@@ -246,14 +281,22 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 					)
 				}
 			},
-			onData: (d) => this._handleReceivedData(d),
+			onData: (d) => {
+				if (this.socket !== socket) return
+				this._handleReceivedData(d)
+			},
 			onConnect: () => {
+				if (this.socket !== socket) {
+					socket.destroy()
+					return
+				}
+
 				if (this.debug) {
 					this.emit('log', 'Connected')
 				}
 
 				this._registeredDevices.clear()
-				this._pendingDevices.clear()
+				this.clearPendingDevices()
 
 				this._connected = true
 				this._pingUnackedCount = 0
@@ -262,6 +305,15 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 				if (!this._pingInterval) {
 					this._pingInterval = setInterval(() => this.sendPing(), PING_INTERVAL)
 				}
+
+				this.clearHandshakeTimeout()
+				this._handshakeTimeout = setTimeout(() => {
+					this._handshakeTimeout = undefined
+					if (this.socket !== socket) return
+
+					this.emit('log', 'Satellite handshake timeout')
+					socket.destroy()
+				}, HANDSHAKE_TIMEOUT)
 
 				if (!this.socket) {
 					// should never hit, but just in case
@@ -273,19 +325,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 			},
 		}
 
-		let socket: ICompanionSatelliteClient
-		switch (this._connectionDetails.mode) {
-			case 'tcp':
-				socket = new CompanionSatelliteTcpClient(socketOptions, this._connectionDetails)
-				break
-			case 'ws':
-				socket = new CompanionSatelliteWsClient(socketOptions, this._connectionDetails)
-				break
-			default:
-				assertNever(this._connectionDetails)
-				this.socket = undefined
-				throw new Error('Invalid connection mode')
-		}
+		const socket = this.socketFactory(socketOptions, this._connectionDetails)
 		this.socket = socket
 
 		this.emit('log', `Connecting to ${formatConnectionUrl(this._connectionDetails)}`)
@@ -335,6 +375,8 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 			clearInterval(this._pingInterval)
 			delete this._pingInterval
 		}
+		this.clearHandshakeTimeout()
+		this.clearPendingDevices()
 
 		if (!this._connected) {
 			return
@@ -590,25 +632,27 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 	}
 
 	private handleAddedDevice(params: Record<string, string | boolean>): void {
+		const deviceId = typeof params.DEVICEID === 'string' ? params.DEVICEID : undefined
+		if (deviceId) this.clearPendingDevice(deviceId)
+
 		if (!params.OK || params.ERROR) {
 			this.emit('log', `Add device failed: ${JSON.stringify(params)}`)
-			if (typeof params.DEVICEID === 'string') {
+			if (deviceId) {
 				this.emit('deviceErrored', {
-					deviceId: params.DEVICEID,
+					deviceId,
 					message: `${params.MESSAGE || 'Unknown Error'}`,
 				})
 			}
 			return
 		}
-		if (typeof params.DEVICEID !== 'string') {
+		if (!deviceId) {
 			this.emit('log', 'Missing DEVICEID in ADD-DEVICE response')
 			return
 		}
 
-		this._registeredDevices.add(params.DEVICEID)
-		this._pendingDevices.delete(params.DEVICEID)
+		this._registeredDevices.add(deviceId)
 
-		this.emit('newDevice', { deviceId: params.DEVICEID })
+		this.emit('newDevice', { deviceId })
 	}
 
 	private handleCaps(params: Record<string, string | boolean>): void {
@@ -639,6 +683,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 	private completeConnection(): void {
 		if (!this._pendingConnected) return
 		this._pendingConnected = false
+		this.clearHandshakeTimeout()
 		setImmediate(() => {
 			this.emit('connected')
 		})
@@ -740,11 +785,9 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 		if (pendingTime && pendingTime > Date.now() - 10000) {
 			throw new Error('Device is already being added')
 		}
-		if (pendingTime) this._pendingDevices.delete(deviceId)
+		if (pendingTime) this.clearPendingDevice(deviceId)
 
 		if (this._connected && this.socket) {
-			this._pendingDevices.set(deviceId, Date.now())
-
 			const transferVariables = Buffer.from(JSON.stringify(props.transferVariables ?? [])).toString('base64')
 
 			const neededColours = new Set<string>()
@@ -809,16 +852,56 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 					...commonProps,
 				})
 			}
+
+			this._pendingDevices.set(deviceId, Date.now())
+			this.clearPendingDeviceTimeout(deviceId)
+			this._pendingDeviceTimeouts.set(
+				deviceId,
+				setTimeout(() => {
+					this._pendingDeviceTimeouts.delete(deviceId)
+					if (!this._pendingDevices.delete(deviceId)) return
+
+					this.emit('log', `Add device timeout: ${deviceId}`)
+					this.emit('deviceErrored', {
+						deviceId,
+						message: 'Timed out waiting for Companion to add device',
+					})
+				}, DEVICE_REGISTRATION_TIMEOUT),
+			)
 		}
 	}
 
 	public removeDevice(deviceId: string): void {
 		if (this._connected && this.socket) {
 			this._registeredDevices.delete(deviceId)
-			this._pendingDevices.delete(deviceId)
+			this.clearPendingDevice(deviceId)
 
 			this.sendMessage('REMOVE-DEVICE', null, deviceId, {})
 		}
+	}
+
+	private clearHandshakeTimeout(): void {
+		if (this._handshakeTimeout) {
+			clearTimeout(this._handshakeTimeout)
+			this._handshakeTimeout = undefined
+		}
+	}
+
+	private clearPendingDeviceTimeout(deviceId: string): void {
+		const timeout = this._pendingDeviceTimeouts.get(deviceId)
+		if (timeout) clearTimeout(timeout)
+		this._pendingDeviceTimeouts.delete(deviceId)
+	}
+
+	private clearPendingDevice(deviceId: string): void {
+		this._pendingDevices.delete(deviceId)
+		this.clearPendingDeviceTimeout(deviceId)
+	}
+
+	private clearPendingDevices(): void {
+		this._pendingDevices.clear()
+		for (const timeout of this._pendingDeviceTimeouts.values()) clearTimeout(timeout)
+		this._pendingDeviceTimeouts.clear()
 	}
 
 	private sendMessage(

--- a/satellite/src/client/client.ts
+++ b/satellite/src/client/client.ts
@@ -378,15 +378,15 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 		this.clearHandshakeTimeout()
 		this.clearPendingDevices()
 
-		if (!this._connected) {
-			return
-		}
+		const socket = this.socket
+		if (!socket) return
 
 		try {
-			this.socket?.end()
-			this.socket = undefined
+			// Keep this socket current until onClose performs the state teardown.
+			// A replacement connect will supersede it in initSocket instead.
+			socket.end()
 		} catch (e) {
-			this.socket = undefined
+			if (this.socket === socket) this.socket = undefined
 			throw e
 		}
 	}
@@ -830,7 +830,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 				const bitmapFormatArgs: SatelliteMessageArgs =
 					bitmapFormat !== 'rgb' ? { BITMAP_FORMAT: bitmapFormat } : {}
 
-				this.sendMessage('ADD-DEVICE', null, deviceId, {
+				this.sendDeviceRegistration(deviceId, {
 					LAYOUT_MANIFEST: Buffer.from(JSON.stringify(props.surfaceManifest)).toString('base64'),
 					...commonProps,
 					...serialArgs,
@@ -842,7 +842,7 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 				const needsText = Object.values(props.surfaceManifest.stylePresets).some((s) => !!s.text)
 				const needsTextStyle = Object.values(props.surfaceManifest.stylePresets).some((s) => !!s.textStyle)
 
-				this.sendMessage('ADD-DEVICE', null, deviceId, {
+				this.sendDeviceRegistration(deviceId, {
 					KEYS_TOTAL: props.gridSize.columns * props.gridSize.rows,
 					KEYS_PER_ROW: props.gridSize.columns,
 					BITMAPS: props.fallbackBitmapSize,
@@ -852,22 +852,6 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 					...commonProps,
 				})
 			}
-
-			this._pendingDevices.set(deviceId, Date.now())
-			this.clearPendingDeviceTimeout(deviceId)
-			this._pendingDeviceTimeouts.set(
-				deviceId,
-				setTimeout(() => {
-					this._pendingDeviceTimeouts.delete(deviceId)
-					if (!this._pendingDevices.delete(deviceId)) return
-
-					this.emit('log', `Add device timeout: ${deviceId}`)
-					this.emit('deviceErrored', {
-						deviceId,
-						message: 'Timed out waiting for Companion to add device',
-					})
-				}, DEVICE_REGISTRATION_TIMEOUT),
-			)
 		}
 	}
 
@@ -902,6 +886,31 @@ export class CompanionSatelliteClient extends EventEmitter<CompanionSatelliteCli
 		this._pendingDevices.clear()
 		for (const timeout of this._pendingDeviceTimeouts.values()) clearTimeout(timeout)
 		this._pendingDeviceTimeouts.clear()
+	}
+
+	private sendDeviceRegistration(deviceId: string, args: SatelliteMessageArgs): void {
+		this._pendingDevices.set(deviceId, Date.now())
+		this.clearPendingDeviceTimeout(deviceId)
+		this._pendingDeviceTimeouts.set(
+			deviceId,
+			setTimeout(() => {
+				this._pendingDeviceTimeouts.delete(deviceId)
+				if (!this._pendingDevices.delete(deviceId)) return
+
+				this.emit('log', `Add device timeout: ${deviceId}`)
+				this.emit('deviceErrored', {
+					deviceId,
+					message: 'Timed out waiting for Companion to add device',
+				})
+			}, DEVICE_REGISTRATION_TIMEOUT),
+		)
+
+		try {
+			this.sendMessage('ADD-DEVICE', null, deviceId, args)
+		} catch (e) {
+			this.clearPendingDevice(deviceId)
+			throw e
+		}
 	}
 
 	private sendMessage(


### PR DESCRIPTION
## Summary

- ignore error, data, connect, and close callbacks from superseded transports
- add a 10-second Satellite handshake watchdog that is independent of ping/pong health
- add a per-device registration watchdog that releases only the unacknowledged device into Satellite's existing retry path
- clear pending registration state when Companion rejects an `ADD-DEVICE` request so the retry is no longer blocked
- add focused tests for incomplete handshakes, stale socket closes, missing acknowledgements, successful acknowledgements, and rejected registrations

## Why

A TCP connection and healthy ping/pong exchange do not guarantee that the Satellite protocol handshake completed. In addition, an `ADD-DEVICE` request can be lost while the shared Satellite connection remains healthy. The latter left the device in `_pendingDevices`, causing `SurfaceManager`'s existing retry handler to skip it indefinitely because `hasDevice()` continued to return true.

These states were reproduced during packet-loss and network-equipment recovery testing while developing [bitfocus/io.bitfocus.companion-plugin#49](https://github.com/bitfocus/io.bitfocus.companion-plugin/pull/49). An extended production soak recorded repeated successful recoveries across five surfaces, including multi-minute outages and repeated failed connection attempts.

Satellite uses one shared Companion connection, so this implementation keeps the recovery scopes separate:

- an incomplete shared protocol handshake recycles the shared transport
- a missing or rejected device registration releases and retries only that device through the existing `deviceErrored` path

## Validation

Run with the repository's Node 24 runtime:

- `yarn test` — 32 tests pass
- `yarn build:ts` — passes
- `yarn lint` — passes
- `yarn build` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when handshakes time out or sockets close unexpectedly.
  * Prevented delayed events from replaced connections from disrupting active sessions.
  * Explicit disconnects now complete reliably through the active connection.
  * Devices are released when registration times out or is rejected.
  * Preserved devices when registration is successfully acknowledged.
  * Added clearer error handling for failed device registration.
  * Prevented unnecessary reconnection attempts after connection activity is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->